### PR TITLE
Add high tech dashboard with event charts

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1,6 +1,7 @@
 body {
     padding-top: 5rem;
-    background-color: #f8f9fa;
+    background-color: #1b1b1b;
+    color: #e9ecef;
 }
 
 .alert.flash-success {
@@ -15,4 +16,8 @@ body {
 
 .navbar-brand {
     font-weight: bold;
+}
+
+.table {
+    color: #e9ecef;
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>ZKTeco СКУД - {% block title %}{% endblock %}</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.3/dist/flatly/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.3/dist/cyborg/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body>
@@ -34,6 +34,8 @@
 
 <!-- Bootstrap JS -->
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+<!-- Chart.js for graphs -->
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
 <!-- Font Awesome -->
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </body>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -30,6 +30,9 @@
     </table>
     <hr>
     <h3>Останні 20 подій</h3>
+    <div class="my-3">
+        <canvas id="eventsChart" height="120"></canvas>
+    </div>
     <table class="table table-sm">
         <thead><tr><th>Час</th><th>Пристрій</th><th>PIN</th><th>Ім'я користувача</th><th>Подія</th></tr></thead>
         <tbody>
@@ -46,4 +49,24 @@
         {% endfor %}
         </tbody>
     </table>
+    <script>
+        const ctx = document.getElementById('eventsChart').getContext('2d');
+        new Chart(ctx, {
+            type: 'line',
+            data: {
+                labels: {{ days|tojson }},
+                datasets: [{
+                    label: 'Подій за день',
+                    data: {{ counts|tojson }},
+                    borderColor: 'rgb(75, 192, 192)',
+                    backgroundColor: 'rgba(75, 192, 192, 0.25)',
+                    tension: 0.4,
+                    fill: true
+                }]
+            },
+            options: {
+                plugins: { legend: { display: false } }
+            }
+        });
+    </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- compute daily event stats in `server.py`
- switch to Bootswatch Cyborg theme
- style pages for dark mode
- render a Chart.js line chart on the dashboard

## Testing
- `python -m py_compile server.py`
- `python -m py_compile check_commands.py data_analyzer.py db_explorer.py debug_sql.py test_commands.py terminal_simulator.py`


------
https://chatgpt.com/codex/tasks/task_e_68623b9c5f5c8321928227492e0d04cd